### PR TITLE
fix: font sans-serif instead of serif fallback

### DIFF
--- a/src/styles/vars.scss
+++ b/src/styles/vars.scss
@@ -32,8 +32,8 @@ $keshav-primary-colour: #0a68e6;
 // ====================================================================
 $page-bg-color: $white;
 $element-shadow: 0 16px 16px 0 rgba(0, 0, 0, 0.04);
-$generic-fonts: WorkSansRegular, Serif, Roboto, Helvetica, Arial, sans-serif;
-$font-priority: WorkSansRegular, Serif, Roboto, Helvetica, Arial, sans-serif;
+$generic-fonts: WorkSansRegular, Roboto, Helvetica, Sans-Serif, Arial, sans-serif;
+$font-priority: WorkSansRegular, Roboto, Helvetica, Sans-Serif, Arial, sans-serif;
 $font-priority-404: sans-serif;
 // ====================================================================
 // Nav bar


### PR DESCRIPTION
If for some reason WorkSansRegular is blocked on wifi networks/is unable to display then the default fallback should be `Roboto, Helvetica, Sans-Serif` in that order replacing the existing `serif` fallback. 